### PR TITLE
Make sytemd service more resilient

### DIFF
--- a/ec2-init.service
+++ b/ec2-init.service
@@ -5,11 +5,16 @@
 
 [Unit]
 Description=EC2 Init
-After=network.target
+After=network-online.target
 
 [Service]
-Type=oneshot
-ExecStart=/usr/sbin/ec2-init
+Type=simple
+Restart=on-failure
+RestartSec=10s
+
+ExecStartPre=/usr/sbin/ec2-init
+ExecStart=/usr/bin/true
+
 StandardOutput=journal+console
 
 [Install]


### PR DESCRIPTION
- ```After=network-online.target```
    - to make sure the script will be able to reach the network.
- ```Type=simple Restart=on-failure RestartSec=10s ExecStartPre=/usr/sbin/ec2-init ExecStart=/usr/bin/true```
    -    To retry script on failure to run